### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,7 +24,7 @@ This Github organization contains code, documentation and additional material el
 - [Simulation](https://github.com/RoboRescueUMA/.github/blob/main/docs/simulation_repos.md)
 - [Electronics](https://github.com/RoboRescueUMA/.github/blob/main/docs/electronics_repos.md)
 - [Utils](https://github.com/RoboRescueUMA/.github/blob/main/docs/utils_repos.md)
-- [Courses and Tutorials](https://github.com/RoboRescueUMA/.github/blob/main/docs/tutorials_repos.md)
+- [Courses and Tutorials](https://github.com/RoboRescueUMA/rr_welcome_kit)
 - [Others](https://github.com/RoboRescueUMA/.github/blob/main/docs/others_repos.md)
 
 


### PR DESCRIPTION
Cambio del enlace de los cursos y tutoriales: se va directo al rr-welcome-kit, y ya dentro de él están los cursos de Github, donde se ha añadido el enlace al github-starter-course que había antes en el enlace de los cursos y tutoriales.